### PR TITLE
Node.js開発向けの.gitignoreを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Dependency directories
+node_modules/
+
+# Build output
+build/
+dist/
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Optional cache
+.npm
+.cache/
+
+# Misc
+.DS_Store
+


### PR DESCRIPTION
## 概要
- Node.js 開発で不要なファイルを除外する `.gitignore` を追加しました

## 変更内容
- `node_modules/` や `dist/` などを無視する設定を記述

## テスト
- 特にテストは存在しないため実行していません

------
https://chatgpt.com/codex/tasks/task_e_684baec0d3e08321a7290d539c4b8cdb