### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v3
@@ -22,5 +26,8 @@ jobs:
       - run: pnpm lint
       - run: pnpm test -- --run
       - run: pnpm build
-      - name: Deploy
-        run: echo "Deploy step"
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+      - uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -52,3 +52,10 @@ export default tseslint.config({
   },
 })
 ```
+
+## デプロイ
+
+このリポジトリは GitHub Pages で公開できます。`main` ブランチに変更をプッシュすると、自動で `dist/` ディレクトリがデプロイされます。
+
+公開されたページは `https://<ユーザー名>.github.io/rubic-solver-v2/` で確認できます。
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/rubic-solver-v2/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- GitHub Actions にページデプロイステップを追加
- GitHub Pages 用に Vite 設定を修正
- README にデプロイ方法を追記

## Testing
- `pnpm lint`
- `pnpm exec vitest run`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684bb54eedf08321a8fe53179f1d6791