### PR TITLE
feat: U面回転の基礎ロジックを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,14 @@ export default tseslint.config({
 
 公開されたページは `https://<ユーザー名>.github.io/rubic-solver-v2/` で確認できます。
 
+
+## Cube API
+
+`Cube` クラスは `move()` メソッドでキューブを回転させます。回転記号を引数に渡してください。
+
+```ts
+const cube = new Cube()
+cube.move('U')
+```
+
+現在対応している回転は `U` のみです。`isSolved()` はすべての面がそろっているかを確認します。

--- a/src/lib/Cube.ts
+++ b/src/lib/Cube.ts
@@ -1,5 +1,54 @@
+export type Move = 'U'
+
 export class Cube {
+  private stickers: string[]
+  private static solvedState = [
+    ...Array(9).fill('U'),
+    ...Array(9).fill('R'),
+    ...Array(9).fill('F'),
+    ...Array(9).fill('D'),
+    ...Array(9).fill('L'),
+    ...Array(9).fill('B'),
+  ]
+
+  constructor() {
+    this.stickers = [...Cube.solvedState]
+  }
+
+  move(moveCode: Move): void {
+    if (moveCode === 'U') {
+      this.rotateU()
+    } else {
+      throw new Error(`Unsupported move: ${moveCode}`)
+    }
+  }
+
+  private rotateU(): void {
+    const s = this.stickers
+    const face = [s[6], s[3], s[0], s[7], s[4], s[1], s[8], s[5], s[2]]
+    for (let i = 0; i < 9; i++) {
+      s[i] = face[i]
+    }
+
+    const temp = [s[18], s[19], s[20]]
+    s[18] = s[36]
+    s[19] = s[37]
+    s[20] = s[38]
+
+    s[36] = s[45]
+    s[37] = s[46]
+    s[38] = s[47]
+
+    s[45] = s[9]
+    s[46] = s[10]
+    s[47] = s[11]
+
+    s[9] = temp[0]
+    s[10] = temp[1]
+    s[11] = temp[2]
+  }
+
   isSolved(): boolean {
-    return true;
+    return this.stickers.every((c, i) => c === Cube.solvedState[i])
   }
 }

--- a/tests/rotation.spec.ts
+++ b/tests/rotation.spec.ts
@@ -1,0 +1,11 @@
+import { Cube } from '../src/lib/Cube'
+import { test, expect } from 'vitest'
+
+test('U face rotated 4 times returns to solved', () => {
+  const cube = new Cube()
+  cube.move('U')
+  cube.move('U')
+  cube.move('U')
+  cube.move('U')
+  expect(cube.isSolved()).toBe(true)
+})


### PR DESCRIPTION
## 概要
- Cube クラスのステッカー状態を実装し、U 回転処理を追加
- U 面を4回回転すると元に戻るテストを追加
- README に Cube API の基本的な使い方を追記

## 動作確認
- `pnpm exec vitest run` でテストが成功することを確認
- `pnpm lint` `pnpm build` がエラーなく終了することを確認


------
https://chatgpt.com/codex/tasks/task_e_684bc409009c8321baa196cbe14fe2b8