### PR TITLE
README更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ export default tseslint.config({
 
 ## デプロイ
 
-このリポジトリは GitHub Pages で公開できます。`main` ブランチに変更をプッシュすると、自動で `dist/` ディレクトリがデプロイされます。
+このリポジトリは GitHub Pages で公開できます。`main` ブランチに変更をプッシュすると、ワークフローにより `dist/` ディレクトリが `gh-pages` ブランチへ自動でデプロイされます。
+リポジトリの Settings → Pages で Source を `gh-pages` ブランチに設定してください。
 
 公開されたページは `https://<ユーザー名>.github.io/rubic-solver-v2/` で確認できます。
 


### PR DESCRIPTION
## 概要
- GitHub Pages の設定手順を追記しました
- gh-pages ブランチへデプロイされることを明記しました

## テスト
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_684bd4e48ce88321901747e5cd54a765